### PR TITLE
Defer flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/bin/aladdin
+++ b/bin/aladdin
@@ -8,6 +8,7 @@ program
   .option('-t, --trace', 'Show full stack trace on error')
   .option('-c, --config [file]', 'Path to config file', 'spec/config.json')
   .option('-f, --format [type]', 'Spec output format. [doc]', 'none')
+  .option('-d, --defer', 'Defers execution of tests.')
   .parse(process.argv);
 
 jasmine(program);

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,6 +80,7 @@ var createRunner = function(html) {
 module.exports = function(program) {
   var trace = program.trace || false;
   var format = program.format || "none";
+  var defer = program.defer || false;
 
   var template = path.join(lib, 'runner.template.html');
 
@@ -87,16 +88,17 @@ module.exports = function(program) {
     loadScripts(program.config, function(scripts) {
       loadSpecs(program.args.shift(), function(specs) {
         var vendor = path.join(__dirname, './../vendor');
-
+        
         var context = { 
           scripts: scripts, 
           specs: specs, 
           lib: lib, 
           vendor: vendor, 
           trace: trace,
-          format: format
+          format: format,
+          executeJasmine: defer ? "// deferred execution" : "jasmine.getEnv().execute();"
         };
-
+        
         var html = render(data.toString(), context);
 
         createRunner(html);

--- a/lib/runner.template.html
+++ b/lib/runner.template.html
@@ -26,7 +26,7 @@
 
       jasmine.getEnv().addReporter(new jasmine.HtmlReporter());
       jasmine.getEnv().addReporter(console_reporter);
-      jasmine.getEnv().execute();
+      {{{executeJasmine}}}
     </script>
   </body>
 </html>

--- a/readme.md
+++ b/readme.md
@@ -54,3 +54,4 @@ Options
     --format, -f [type]   Specify a format type for the spec output. Options "doc"
     --config, -c [file]   Path to config file
     --trace, -t           Show full stack traces
+    --defer, -d           Defers execution of tests, requiring a manual call to `jasmine.getEnv().execute();`


### PR DESCRIPTION
Added a --defer flag that defers automatic execution of jasmine. This is necessary for systems like RequireJS (AMD) that depend on async loading.
