### PR TITLE
Make Aladdin compatible with Windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var walkdir = require('walkdir');
 var Mustache = require('mustache');
 var glob = require('glob');
+var globWin = require('glob-whatev')
 
 var lib = path.join(__dirname, './../lib');
 
@@ -19,7 +20,12 @@ var loadScripts = function(config, f) {
       var scripts = require(path.join(process.cwd(), config));
 
       scripts.forEach(function(script) {
-        files = glob.sync(path.join(process.cwd(), script))
+        var files;
+        if(process.platform === 'win32'){
+          files = globWin.glob(path.join(process.cwd(), script));
+        } else {
+          files = glob.sync(path.join(process.cwd(), script));
+        }
         sourceFiles = sourceFiles.concat(files);
       });
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "walkdir": "0.0.4",
     "mustache": "0.5.2",
     "glob": "3.1.12",
-    "commander": "1.0.3"
+    "commander": "1.0.3",
+    "glob-whatev": "0.1.8"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
- On Windows, use [glob-whatev](https://github.com/cowboy/node-glob-whatev) instead of glob.  Glob is not compatible with Windows.
- This fix uses a conditional to branch between the two globbing libraries.  I have not tested glob-whatev on a non-Windows machine.  If it does work in non-Windows environments, then it would make sense to remove the conditional, discontinue use of Glob, and switch to Glob-Whatev entirely.
