### PR TITLE
Fixed issue with console.log

### DIFF
--- a/lib/run_jasmine_test.coffee
+++ b/lib/run_jasmine_test.coffee
@@ -30,7 +30,7 @@ runner = new PhantomJasmineRunner(page)
 page.onConsoleMessage = (msg) ->
   console.log msg
 
-  finished = page.evaluate(-> console_reporter.finished)
+  finished = page.evaluate(-> console_reporter? and console_reporter.finished)
 
   if finished
     runner.terminate()

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git@github.com:rlayte/aladdin.git"
   },
   "main": "lib/run_jasmine_test.coffee",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "bin": {
     "aladdin": "./bin/aladdin"
   },


### PR DESCRIPTION
Using console.log in any of the source files resulted in the following output to the terminal window:

ReferenceError: Can't find variable: console_reporter

  phantomjs://webpage.evaluate():2
  phantomjs://webpage.evaluate():3
  phantomjs://webpage.evaluate():3

This was because the onConsoleMessage handler expected console_reporter to exist, but runner.html includes all source files before declaring the console_reporter variable.
